### PR TITLE
Update getting started text

### DIFF
--- a/app/views/blocks/getting-started.html
+++ b/app/views/blocks/getting-started.html
@@ -4,22 +4,24 @@
 	<div id="quickstart-bs">
 		<h3>Using the build service</h3>
 
-		<p>Add the following token to your <a href="http://origami.ft.com/docs/developer-guide/build-service">build service</a>
+		<p>Add the following token to your
 		{% if has_js and has_css %}<code>script</code> and <code>link</code> tags
 		{% elseif has_js %}<code>script</code> tag
 		{% elseif has_css %}<code>link</code> tag{% endif %}
 		(<a class="o-overlay-trigger" data-o-overlay-id="overlay" data-o-overlay-src="#how-do-i-build-service" data-o-overlay-heading-shaded="true" data-o-overlay-heading-title="Using the Build Service" data-o-overlay-zindex="20" aria-pressed="false" aria-haspopup="true" href="#how-do-i-build-service">how do I do that?</a>):</p>
 		<pre class="quickstart-tag"><code>{{module_name}}@^{{tag_name}}</code></pre>
+
+		<p>For more information see the <a href="http://origami.ft.com/docs/developer-guide/build-service">Origami build service</a>.</p>
 	</div>
 
 	<div id="quickstart-manual">
 		<h3>Using a manual build process</h3>
 
-		<p>Run the following command in the root directory of your project:</p>
+		<p>Run the following command in the root directory of your project, to add this dependency to your <code>bower.json</code> file:</p>
 
 		<pre class="quickstart-tag"><code class="lang-json">bower install --save "{{module_name}}"@"^{{tag_name}}"</code></pre>
 
-		<p>This will add this dependency to your <code>bower.json</code> file. For more information see the <a href="http://origami.ft.com/docs/developer-guide/building-modules/">Origami build process</a>.</p>
+		<p>For more information see the <a href="http://origami.ft.com/docs/developer-guide/building-modules/">Origami build process</a>.</p>
 
 	</div>
 </section>


### PR DESCRIPTION
Depends on #11.

Updates the getting started text to be more consistent with each other and not confuse the two links in the original build service example.

Trello: https://trello.com/c/iEkIcUnY
