### PR TITLE
Temporarily hide category headers

### DIFF
--- a/app/classes/Controllers/ComponentListing.php
+++ b/app/classes/Controllers/ComponentListing.php
@@ -38,10 +38,10 @@ class ComponentListing extends BaseController {
 			);
 
 		foreach (Component::findAll('c.is_origami IS TRUE') as $component) {
-			$cat = $component->origami_category;
-			if ($cat === '') {
+			// $cat = $component->origami_category;
+			// if ($cat === '') {
 				$cat = 'uncategorised';
-			}
+			// }
 
 			if ($component->latest_stable_version) {
 				$viewdata[$cat]['modules'][] = array_merge(

--- a/app/views/component_listing.html
+++ b/app/views/component_listing.html
@@ -29,7 +29,7 @@
 			<tbody>
 			{% for group in components %}
 				{% if group.modules is not empty %}
-					<tr class="component-group">
+					<tr class="component-group" style="display:none">
 						<td><h3>{{group.title}}</h3></td><td></td><td></td>
 					</tr>
 

--- a/app/views/component_listing.html
+++ b/app/views/component_listing.html
@@ -17,7 +17,7 @@
 			<input type="checkbox" name="support" value="maintained" class="o-forms-checkbox o-forms-checkbox--small" id="check-maintained" checked><label for="check-maintained" class="o-forms-label">Maintained</label>
 			<input type="checkbox" name="support" value="deprecated" class="o-forms-checkbox o-forms-checkbox--small" id="check-deprecated"><label for="check-deprecated" class="o-forms-label">Deprecated</label>
 			<input type="checkbox" name="support" value="dead" class="o-forms-checkbox o-forms-checkbox--small" id="check-dead"><label for="check-dead" class="o-forms-label">Dead</label>
-			<input type="checkbox" name="support" value="experimental" class="o-forms-checkbox o-forms-checkbox--small" id="check-experimental" checked><label for="check-experimental" class="o-forms-label">Experimental</label>
+			<input type="checkbox" name="support" value="experimental" class="o-forms-checkbox o-forms-checkbox--small" id="check-experimental"><label for="check-experimental" class="o-forms-label">Experimental</label>
 		</div>
 	</form>
 


### PR DESCRIPTION
Quick hack to hide the category headers and set them all to the same category.

Also removes the experimental modules from displaying by default.
