### PR TITLE
Add metric logging for repo discovery and db access

### DIFF
--- a/app/classes/Controllers/Refresh.php
+++ b/app/classes/Controllers/Refresh.php
@@ -32,6 +32,7 @@ final class Refresh extends BaseController {
 
 			} catch (\Exception $e) {
 				if ($e->getMessage() === 'Tag not found') {
+					$this->app->metrics->increment($this->app->metrics_prefix . 'component.refresh.delete');
 					$this->version->delete();
 					$this->resp->setJSON("/components");
 					return;

--- a/app/classes/Origami/Component.php
+++ b/app/classes/Origami/Component.php
@@ -60,13 +60,13 @@ final class Component extends Model {
 		self::$app->logger->debug('Searching for new versions', array('component'=>$this->module_name));
 		$apiclass = '\\GitAPIClients\\'.$this->host_type;
 		$api = new $apiclass(self::$app->logger);
-		$discover_versions_start = 0;
+		$discover_versions_start = microtime(true);
 		$newversions = $api->discoverVersions($this->git_repo_url, array_keys($this->versions));
 
 		$discover_versions_diff = microtime(true) - $discover_versions_start;
 		self::$app->metrics->timing(self::$app->metrics_prefix . '.discoverVersions.apiRequest', $discover_versions_diff);
 
-		$update_versions_start = 0;
+		$update_versions_start = microtime(true);
 		foreach ($newversions as $version) {
 			$versionobj = ComponentVersion::findOrCreate($this, $version['tag_name']);
 
@@ -94,7 +94,7 @@ final class Component extends Model {
 		$versions = $this->versions;
 		if (empty($versions)) return;
 
-		$build_versions_start = 0;
+		$build_versions_start = microtime(true);
 
 		$version = $latest = end($versions);
 		while ($version && ($version->is_valid === null or !$unbuiltonly) && $depth) {

--- a/app/classes/Origami/Component.php
+++ b/app/classes/Origami/Component.php
@@ -60,8 +60,13 @@ final class Component extends Model {
 		self::$app->logger->debug('Searching for new versions', array('component'=>$this->module_name));
 		$apiclass = '\\GitAPIClients\\'.$this->host_type;
 		$api = new $apiclass(self::$app->logger);
+		$discover_versions_start = 0;
 		$newversions = $api->discoverVersions($this->git_repo_url, array_keys($this->versions));
 
+		$discover_versions_diff = microtime(true) - $discover_versions_start;
+		self::$app->metrics->timing(self::$app->metrics_prefix . '.discoverVersions.apiRequest', $discover_versions_diff);
+
+		$update_versions_start = 0;
 		foreach ($newversions as $version) {
 			$versionobj = ComponentVersion::findOrCreate($this, $version['tag_name']);
 
@@ -70,12 +75,16 @@ final class Component extends Model {
 				$versionobj->save();
 				$this->data['versions'][$version['tag_name']] = $versionobj;
 
+				self::$app->metrics->increment(self::$app->metrics_prefix . 'component.discoverVersions.new');
 				self::$app->logger->info('Discovered new version', array(
 					'module_name' => $this->module_name,
 					'tag' => $version['tag_name'],
 				));
 			}
 		}
+
+		$update_versions_diff = microtime(true) - $update_versions_start;
+		self::$app->metrics->timing(self::$app->metrics_prefix . '.discoverVersions.updateDB', $update_versions_diff);
 
 		$this->_initialiseVersions();
 	}
@@ -84,6 +93,8 @@ final class Component extends Model {
 	public function buildVersions($unbuiltonly = true, $depth = 5) {
 		$versions = $this->versions;
 		if (empty($versions)) return;
+
+		$build_versions_start = 0;
 
 		$version = $latest = end($versions);
 		while ($version && ($version->is_valid === null or !$unbuiltonly) && $depth) {
@@ -114,6 +125,7 @@ final class Component extends Model {
 				if (!$version->is_valid and $unbuiltonly) break;
 			} catch (\Exception $e) {
 				if ($e->getMessage() === 'Tag not found') {
+					self::$app->metrics->increment(self::$app->metrics_prefix . 'component.buildVersions.delete');
 					$version->delete();
 					return;
 				}
@@ -132,6 +144,9 @@ final class Component extends Model {
 		}
 
 		$versiontags = array_keys($versions);
+
+		$build_versions_diff = microtime(true) - $build_versions_start;
+		self::$app->metrics->timing(self::$app->metrics_prefix . '.buildVersions.timing', $build_versions_diff);
 		self::$app->logger->info('buildVersions', array(
 			'module' => $this->module_name,
 			'latest_tag' => end($versiontags),

--- a/app/classes/Origami/RepositoryDiscovery.php
+++ b/app/classes/Origami/RepositoryDiscovery.php
@@ -16,6 +16,7 @@ final class RepositoryDiscovery {
 	public static function search($data, $app) {
 
 		$metrics = $app->metrics;
+		$metrics_prefix = $app->metrics_prefix;
 		$app->logger->info('Beginning Origami component discovery');
 
 		// Discover repos
@@ -37,13 +38,13 @@ final class RepositoryDiscovery {
 					$component->host_type = $source->api->type;
 					$components[$repository['name']] = $component;
 					$foundcount++;
-					$metrics->increment($this->app->metrics_prefix . 'discovery.found');
+					$metrics->increment($metrics_prefix . 'discovery.found');
 				}
 			}
 
 			$api_query_diff = microtime(true) - $api_query_start;
 
-			$metrics->timing($this->app->metrics_prefix . 'discovery. ' .$source->api->type. '.apiRequest', $api_query_diff);
+			$metrics->timing($metrics_prefix . 'discovery. ' .$source->api->type. '.apiRequest', $api_query_diff);
 			$app->logger->info('Searched '.$source->name.', found repositories: '.$foundcount);
 		}
 
@@ -58,12 +59,12 @@ final class RepositoryDiscovery {
 				$component->datetime_last_discovered = new \DateTime();
 				$component->save();
 				$component->discoverVersions();
-				$metrics->increment($this->app->metrics_prefix . 'discovery.origami');
+				$metrics->increment($metrics_prefix . 'discovery.origami');
 				if ($component->latest_version and $component->latest_version->is_valid === null) {
 					$component->buildVersions();
 					if ($component->latest_version->is_valid) {
 						$newlist[$component->module_name] = $component;
-						$metrics->increment($this->app->metrics_prefix . 'discovery.new_component');
+						$metrics->increment($metrics_prefix . 'discovery.new_component');
 					}
 				}
 			}

--- a/app/classes/Origami/RepositoryDiscovery.php
+++ b/app/classes/Origami/RepositoryDiscovery.php
@@ -20,7 +20,7 @@ final class RepositoryDiscovery {
 
 		// Discover repos
 		foreach ($data->sources as $source) {
-			$api_query_start = 0;
+			$api_query_start = microtime(true);
 
 			$className = '\\GitAPIClients\\' . $source->api->type;
 			$users = isset($source->api->users) ? $source->api->users : null;

--- a/app/scripts/updateregistry
+++ b/app/scripts/updateregistry
@@ -15,12 +15,12 @@ Model::useDI($app);
 use \Origami\RepositoryDiscovery;
 use \Psr\Log\LogLevel;
 
-
 $app->db_read->setReconnectOnFail();
 $app->db_write->setReconnectOnFail();
 
 $app->logger->setHandlerMinSeverity('stop', LogLevel::EMERGENCY);
 
+$updateTimeStart = microtime(true);
 // Clean up any previous scripts that terminated without finishing
 $app->db_write->query('DELETE FROM meta WHERE meta_key=%s and updated < (NOW() - INTERVAL 1 DAY)', 'cron_running_host');
 
@@ -43,7 +43,16 @@ if (!$module_sources) {
 		}
 
 		$app->db_write->query('DELETE FROM meta WHERE meta_key=%s', 'cron_running_host');
+
+		$updateTimeDiff = microtime(true) - $updateTimeStart;
+		$app->metrics->timing($app->metrics_prefix . 'updatescript.time', $updateTimeDiff);
     } else {
+    	$app->metrics->increment(self::$app->metrics_prefix . 'updatescript.alreadyRunning');
         $app->logger->notice("Discovery script is already running");
     }
 }
+
+// Flush the metrics to graphite at the end of every run
+// Use "@" to catch/dismiss any errors this throws as it shouldn't effect the running of the service.
+// Would work the same as doing try { ... } catch {}, except fsockopen doesn't throw exceptions.
+@$app->metrics->flush();

--- a/app/scripts/updateregistry
+++ b/app/scripts/updateregistry
@@ -43,13 +43,13 @@ if (!$module_sources) {
 		}
 
 		$app->db_write->query('DELETE FROM meta WHERE meta_key=%s', 'cron_running_host');
-
-		$updateTimeDiff = microtime(true) - $updateTimeStart;
-		$app->metrics->timing($app->metrics_prefix . 'updatescript.time', $updateTimeDiff);
     } else {
     	$app->metrics->increment(self::$app->metrics_prefix . 'updatescript.alreadyRunning');
         $app->logger->notice("Discovery script is already running");
     }
+
+    $updateTimeDiff = microtime(true) - $updateTimeStart;
+    $app->metrics->timing($app->metrics_prefix . 'updatescript.time', $updateTimeDiff);
 }
 
 // Flush the metrics to graphite at the end of every run


### PR DESCRIPTION
This adds some more metrics for tracking the repository discovery script and for when db deletions happen, based on the series of errors we've had recently. on production. 

Suggestions for more things that should be tracked are welcome.
