### PR TITLE
Add open in new tab to demos

### DIFF
--- a/app/views/blocks/demo.html
+++ b/app/views/blocks/demo.html
@@ -9,7 +9,11 @@
 			<li role="tab"><a href="#code-{{ demo.name|slugify}}">HTML</a></li>
 		</ul>
 
-		<a class="demo__jsbin-link" href="/components/{{module_name}}@{{tag_name}}/demos/edit/{{demo.name}}" target="_blank">Open in JSBin <i class="fa fa-external-link"></i></a>
+		<div class="demo__jsbin-link demo__external-links">
+			<span>Open in:</span>
+			<a class="" href="/components/{{module_name}}@{{tag_name}}/demos/edit/{{demo.name}}" target="_blank">JSBin <i class="fa fa-external-link"></i></a>
+			<a class="" href="https://{{ SERVER.BUILD_SERVICE_HOST }}/v2/demos/{{module_name}}@{{tag_name}}/{{demo.name}}" target="_blank">New tab <i class="fa fa-external-link"></i></a>
+		</div>
 	</div>
 
 	<div id="demo-{{ demo.name|slugify}}" class="o-tabs__tabpanel">

--- a/public/scss/partials/_demos.scss
+++ b/public/scss/partials/_demos.scss
@@ -8,16 +8,20 @@
 	position: relative;
 }
 
-.demo__jsbin-link {
+.demo__external-links {
 	position: absolute;
 	bottom: 5px;
 	right: 0;
 	list-style: none;
 	font-size: 15px;
-	font-weight: 600;
 	text-transform: none;
 	text-decoration: none;
 	background-color: #fff;
+
+	a {
+		padding-left: 5px;
+		font-weight: 600;
+	}
 }
 
 .demo__jsbin-link i {


### PR DESCRIPTION
Adds an open in new tab button to each demo alongside the JSBin link.

![screen shot 2016-09-01 at 16 15 14](https://cloud.githubusercontent.com/assets/1240073/18172914/645d6c38-705f-11e6-8536-64333ccb597f.png)

Closes #45 
