### PR TITLE
Imageset pages

### DIFF
--- a/app/classes/Controllers/ComponentDetail.php
+++ b/app/classes/Controllers/ComponentDetail.php
@@ -92,6 +92,13 @@ class ComponentDetail extends BaseController {
 		if ($this->version->has_css) $docs_sections++;
 		$this->addViewData('docs_sections', $docs_sections);
 
+		if ($this->version->image_list) {
+			$imageset_images = json_decode($this->version->image_list);
+			foreach ($imageset_images as $imgset) {
+				$this->addViewData('imageset_list', $imgset);
+			}
+		}
+
 		// Certain older versions of o-colors cannot be demoed via the /demo endpoint
 		if ($this->component->module_name === 'o-colors' && version_compare($this->version->tag_name, '3.3.0', '<=')) {
 			$this->addViewData('force_old_demo_url', true);

--- a/app/classes/Controllers/ComponentDetail.php
+++ b/app/classes/Controllers/ComponentDetail.php
@@ -94,6 +94,12 @@ class ComponentDetail extends BaseController {
 
 		if ($this->version->image_list) {
 			$imageset_images = json_decode($this->version->image_list);
+			$this->addViewData('imageset_scheme', $imageset_images->imageset_data->scheme);
+			$this->addViewData('imageset_path', $imageset_images->imageset_data->pathToImages);
+			// Remove the imageset_data property so the following foreach works
+			// regardless of the property name of the images
+			unset($imageset_images->imageset_data);
+
 			foreach ($imageset_images as $imgset) {
 				$this->addViewData('imageset_list', $imgset);
 			}

--- a/app/classes/Origami/Component.php
+++ b/app/classes/Origami/Component.php
@@ -18,7 +18,7 @@ final class Component extends Model {
 
 	protected $fields = array('id', 'module_name', 'keywords', 'origami_category', 'git_repo_url', 'is_origami', 'host_type', 'datetime_last_discovered', 'recent_commit_count');
 	protected $datefields = array('datetime_last_discovered');
-	protected static $categories = array('primitives', 'components', 'layouts', 'utilities', 'uncategorised');
+	protected static $categories = array('primitives', 'components', 'layouts', 'utilities', 'imagesets', 'uncategorised');
 
 	public function __construct() {
 		parent::__construct();

--- a/app/classes/Origami/Component.php
+++ b/app/classes/Origami/Component.php
@@ -107,7 +107,7 @@ final class Component extends Model {
 				$this->data['keywords'] = $latest->keywords;
 				$this->data['is_origami'] = $latest->is_valid;
 				if (empty($latest->origami_category) && $latest->origami_type === 'imageset') {
-					$this->data['origami_category'] = 'imageset';
+					$this->data['origami_category'] = 'imagesets';
 				} else {
 					$this->data['origami_category'] = $latest->origami_category;
 				}

--- a/app/classes/Origami/Component.php
+++ b/app/classes/Origami/Component.php
@@ -102,6 +102,9 @@ final class Component extends Model {
 			$isnew = ($version->is_valid === null);
 			try {
 				$version->build();
+				if ($version->origami_type === 'imageset') {
+					$version->buildImageList();
+				}
 				$version->save();
 
 				$this->data['keywords'] = $latest->keywords;

--- a/app/classes/Origami/Component.php
+++ b/app/classes/Origami/Component.php
@@ -106,7 +106,12 @@ final class Component extends Model {
 
 				$this->data['keywords'] = $latest->keywords;
 				$this->data['is_origami'] = $latest->is_valid;
-				$this->data['origami_category'] = $latest->origami_category;
+				if (empty($latest->origami_category) && $latest->origami_type === 'imageset') {
+					$this->data['origami_category'] = 'imageset';
+				} else {
+					$this->data['origami_category'] = $latest->origami_category;
+				}
+
 				$this->save();
 
 				// If this is the latest version of a module which is valid (or we're doing a deep scan), rebuild last REBUILD_DEPENDENTS_DEPTH versions of all direct dependents

--- a/app/classes/Origami/ComponentVersion.php
+++ b/app/classes/Origami/ComponentVersion.php
@@ -353,6 +353,30 @@ final class ComponentVersion extends Model {
 			}
 
 			if (isset($responseJson)) {
+				$oiu_url = 'https://raw.githubusercontent.com/Financial-Times/origami-imageset-uploader/master/imageset-map.json';
+
+				$oiu_request = new HTTPRequest($oiu_url);
+				$oiu_request->setTimeLimit(120);
+				$oiu_request->setMaxRetries(2);
+				$oiu_request->setRetryInterval(5);
+
+				// Send the request
+				try {
+					$oiu_response = $oiu_request->send();
+				} catch (Exception $e) {
+					self::$app->logger->error('HTTP failure querying GitHub raw', $e->getMessage());
+					return false;
+				}
+
+				if ($oiu_response->getResponseStatusCode() == 200) {
+					$oui_json = json_decode($oiu_response->getBody());
+
+					if (property_exists($oui_json, $this->component->module_name)) {
+						$imageset_map_data = $oui_json->{$this->component->module_name};
+						$responseJson->imageset_data = $imageset_map_data;
+					}
+				}
+
 				$this->image_list = json_encode($responseJson);
 			}
 		}

--- a/app/classes/Origami/ComponentVersion.php
+++ b/app/classes/Origami/ComponentVersion.php
@@ -373,6 +373,12 @@ final class ComponentVersion extends Model {
 
 					if (property_exists($oui_json, $this->component->module_name)) {
 						$imageset_map_data = $oui_json->{$this->component->module_name};
+
+						if ($this->component->module_name === 'fticons') {
+							$scheme_version = '-v' . explode('.', $this->tag_name)[0];
+							$imageset_map_data->scheme .= $scheme_version;
+						}
+
 						$responseJson->imageset_data = $imageset_map_data;
 					}
 				}

--- a/app/scripts/updateregistry
+++ b/app/scripts/updateregistry
@@ -44,7 +44,7 @@ if (!$module_sources) {
 
 		$app->db_write->query('DELETE FROM meta WHERE meta_key=%s', 'cron_running_host');
     } else {
-    	$app->metrics->increment(self::$app->metrics_prefix . 'updatescript.alreadyRunning');
+    	$app->metrics->increment($app->metrics_prefix . 'updatescript.alreadyRunning');
         $app->logger->notice("Discovery script is already running");
     }
 

--- a/app/views/blocks/component-information.html
+++ b/app/views/blocks/component-information.html
@@ -23,7 +23,7 @@
 		{% if origami_type == 'service' %}
 			<dt>Live URL:</dt>
 			<dd><a href="{{service_url}}">{{service_url}}</a></dd>
-		{% else %}
+		{% elseif origami_type != 'imageset' %}
 			<dt>Bundle sizes:</dt>
 			<dd>
 				{% if bundlesize_js %}
@@ -41,57 +41,60 @@
 		<dt>Support status (<a href="http://origami.ft.com/docs/syntax/origamijson/">Learn more):</a></dt>
 		<dd><span class="label-{{support_status|slugify}}">{{support_status|capitalize}}</span> (as of <span class="version-number">{{support_status_version}}</span>)</dd>
 
-		<dt>Installable?</dt>
-		<dd>
-			<span class="label-{% if is_valid %}pass{% endif %}{% if not is_valid %}fail{% endif %}">
-				{% if is_valid == 1 %}
-					OK
-				{% elseif is_valid == 0 %}
-					Not installable, fails build tests
-				{% else %}
-					Unknown
+		{% if origami_type != 'imageset' %}
+
+			<dt>Last indexed</dt>
+			<dd>
+				{{datetime_last_cached|date('j M Y H:i:s')}} (<a href="/components/{{module_name}}@{{tag_name}}/refresh" class="link-refresh">Build now</a>)
+			</dd>
+
+			<dt>Installable?</dt>
+			<dd>
+				<span class="label-{% if is_valid %}pass{% endif %}{% if not is_valid %}fail{% endif %}">
+					{% if is_valid == 1 %}
+						OK
+					{% elseif is_valid == 0 %}
+						Not installable, fails build tests
+					{% else %}
+						Unknown
+					{% endif %}
+					<a href="https://{{ SERVER.BUILD_SERVICE_HOST }}/modules/{{module_name}}@{{tag_name}}" title="View build test results"><i class="fa fa-info-circle"></i></a>
+				</span>
+			</dd>
+
+			<dt>Dependencies</dt>
+			<dd>
+				{% if not dependencies %}
+					<span>None</span>
 				{% endif %}
-				<a href="https://{{ SERVER.BUILD_SERVICE_HOST }}/modules/{{module_name}}@{{tag_name}}" title="View build test results"><i class="fa fa-info-circle"></i></a>
-			</span>
-		</dd>
+				{% if dependencies %}
+				<table class="component-details__dependencies">
+					{% for dependency in dependencies %}
+					<tr>
+						<td>{% if dependency.id %}<a href="/components/{{dependency.child_component_name}}">{% endif %}{{dependency.child_component_name}}{% if dependency.id %}</a>{% endif %}</td>
+						<td><span class='version-number'>{{dependency.child_component_target}}</span></td>
+						<td>
+							{% if dependency.uptodate %}
+							<span title='The latest version of the dependency can be used' class='label-active'>OK</span>
+							{% else %}
+							<span title='Forced by this constraint to use an older version of the dependency' class='label-experimental'>Out of date</span>
+							{% endif %}
+						</td>
+						<td><span title='Latest available version of the dependency' class='version-number'>{{dependency.latest}}</span></td>
+					</tr>
+					{% endfor %}
+				</table>
+				{% endif %}
+			</dd>
 
-		<dt>Last indexed</dt>
-		<dd>
-			{{datetime_last_cached|date('j M Y H:i:s')}} (<a href="/components/{{module_name}}@{{tag_name}}/refresh" class="link-refresh">Build now</a>)
-		</dd>
-
-		<dt>Dependencies</dt>
-		<dd>
-			{% if not dependencies %}
-				<span>None</span>
-			{% endif %}
-			{% if dependencies %}
-			<table class="component-details__dependencies">
-				{% for dependency in dependencies %}
-				<tr>
-					<td>{% if dependency.id %}<a href="/components/{{dependency.child_component_name}}">{% endif %}{{dependency.child_component_name}}{% if dependency.id %}</a>{% endif %}</td>
-					<td><span class='version-number'>{{dependency.child_component_target}}</span></td>
-					<td>
-						{% if dependency.uptodate %}
-						<span title='The latest version of the dependency can be used' class='label-active'>OK</span>
-						{% else %}
-						<span title='Forced by this constraint to use an older version of the dependency' class='label-experimental'>Out of date</span>
-						{% endif %}
-					</td>
-					<td><span title='Latest available version of the dependency' class='version-number'>{{dependency.latest}}</span></td>
-				</tr>
-				{% endfor %}
-			</table>
-			{% endif %}
-		</dd>
-
-		<dt>Dependents</dt>
-		<dd>
-			{% if not dependents %}
-				<span>None</span>
-			{% endif %}
-<!-- No indentation, to ensure there's no space in between items: -->
-{% for dependent in dependents %}<span class="component-detail__dependent">{% if dependent.id %}<a href="/components/{{dependent.module_name}}">{% endif %}{{dependent.module_name}}{% if dependent.id %}</a>{% endif %}</span>{% endfor %}
-		</dd>
+			<dt>Dependents</dt>
+			<dd>
+				{% if not dependents %}
+					<span>None</span>
+				{% endif %}
+	<!-- No indentation, to ensure there's no space in between items: -->
+	{% for dependent in dependents %}<span class="component-detail__dependent">{% if dependent.id %}<a href="/components/{{dependent.module_name}}">{% endif %}{{dependent.module_name}}{% if dependent.id %}</a>{% endif %}</span>{% endfor %}
+			</dd>
+		{% endif %}
 	</dl>
 </section>

--- a/app/views/blocks/component-nav.html
+++ b/app/views/blocks/component-nav.html
@@ -13,7 +13,7 @@
 					<h3 class="component-navigation__title">{{group.title}}</h3>
 				</li>
 				{% for component in group.modules %}
-					{% if (component.support_status == 'active' or component.support_status == 'maintained') and component.origami_type != 'service' or  %}
+					{% if (component.support_status == 'active' or component.support_status == 'maintained') and component.origami_type != 'service' %}
 						<li class="component-navigation__item js-searchable type-{{component.origami_type}} support-{{component.support_status|slugify}}{% if component.module_name == module_name %} component-navigation__item--active{% endif %}"><a data-module-name--js data-name="{{component.module_name}}" data-keywords="{{component.keywords}}" href="/components/{{component.module_name}}@{{component.tag_name}}">{{component.module_name}}</a></li>
 					{% endif %}
 				{% endfor %}

--- a/app/views/blocks/component-nav.html
+++ b/app/views/blocks/component-nav.html
@@ -13,7 +13,7 @@
 					<h3 class="component-navigation__title">{{group.title}}</h3>
 				</li>
 				{% for component in group.modules %}
-					{% if (component.support_status == 'active' or component.support_status == 'maintained') and component.origami_type == 'module' %}
+					{% if (component.support_status == 'active' or component.support_status == 'maintained') and component.origami_type != 'service' or  %}
 						<li class="component-navigation__item js-searchable type-{{component.origami_type}} support-{{component.support_status|slugify}}{% if component.module_name == module_name %} component-navigation__item--active{% endif %}"><a data-module-name--js data-name="{{component.module_name}}" data-keywords="{{component.keywords}}" href="/components/{{component.module_name}}@{{component.tag_name}}">{{component.module_name}}</a></li>
 					{% endif %}
 				{% endfor %}

--- a/app/views/blocks/imageset-demo.html
+++ b/app/views/blocks/imageset-demo.html
@@ -4,6 +4,13 @@
 	</header>
 
 	<div class="demo__frame-container">
-		{{imageset_demo}}
+		<div class="imageset-demo">
+			{% for image in imageset_list %}
+				<div class="imageset-demo__item">
+					<img src="//image.webservices.ft.com/v1/images/raw/fticon-v1:{{image.name}}?source=origami-registry" alt="{{image.name}}" class="imageset-demo__image">
+					<p class="imageset-demo__title">{{image.name}}</p>
+				</div>
+			{% endfor %}
+		</div>
 	</div>
 </div>

--- a/app/views/blocks/imageset-demo.html
+++ b/app/views/blocks/imageset-demo.html
@@ -1,6 +1,6 @@
 <div class="demo demo--imageset">
 	<header class="demo__header">
-		<h2 class="demo__title">Imageset images</h2>
+		<h2 class="demo__title">Image set</h2>
 	</header>
 
 	<div class="demo__frame-container">

--- a/app/views/blocks/imageset-demo.html
+++ b/app/views/blocks/imageset-demo.html
@@ -1,0 +1,9 @@
+<div class="demo demo--imageset">
+	<header class="demo__header">
+		<h2 class="demo__title">Imageset images</h2>
+	</header>
+
+	<div class="demo__frame-container">
+		{{imageset_demo}}
+	</div>
+</div>

--- a/app/views/component-detail.html
+++ b/app/views/component-detail.html
@@ -36,6 +36,19 @@
 						<p><a href="{{service_url}}" class="btn btn-lg btn-primary active"><i class="glyphicon glyphicon-circle-arrow-right"></i> Load service</a> &nbsp; (services host their own documentation)</p>
 					{% endif %}
 
+					{% if origami_type == 'imageset' %}
+						<h3>Use the imageset</h3>
+						<p>Imageset images can be loaded directly using the imageservice. This shortcode for this imageset is: ...</p>
+
+						<h4>Download the full imageset</h4>
+
+						<p>To download the full imageset, download the repo from GitHub using the button below. You&rsquo;ll find all the image files in the <code>/src</code> folder.</p>
+
+						<a href="{{repo_home_url}}/archive/master.zip" class="o-buttons o-buttons--big o-registry__github-button">Download the imageset</a>
+
+
+					{% endif %}
+
 					{% if origami_type == 'module' and (has_js or has_css) %}
 						{% include "blocks/getting-started.html" %}
 					{% endif %}

--- a/app/views/component-detail.html
+++ b/app/views/component-detail.html
@@ -44,7 +44,7 @@
 
 						<p>To load an image from this image set, use the following URL for the Image Service:</p>
 
-						<pre><code class="lang-html">//image.webservices.ft.com/v1/images/raw/{{imageset_scheme}}:{image-name}</code></pre>
+						<pre><code class="lang-html">//image.webservices.ft.com/v1/images/raw/{{imageset_scheme}}:{image-name}?source={your-source-here}</code></pre>
 
 						<h4>Download the full image set</h4>
 

--- a/app/views/component-detail.html
+++ b/app/views/component-detail.html
@@ -39,18 +39,18 @@
 					{% if origami_type == 'imageset' %}
 						<h2>Quick start</h2>
 
-						<h3>Use the imageset</h3>
-						<p>Imageset images can be loaded directly using the imageservice. This shortcode for this imageset is: <code>{{imageset_scheme}}</code></p>
+						<h3>Use the image set</h3>
+						<p>Image set images can be loaded directly using the Image Service. This scheme for this image set is: <code>{{imageset_scheme}}</code></p>
 
-						<p>To load an image from this imageset, use the following URL for the build service:</p>
+						<p>To load an image from this image set, use the following URL for the Image Service:</p>
 
 						<pre><code class="lang-html">//image.webservices.ft.com/v1/images/raw/{{imageset_scheme}}:{image-name}</code></pre>
 
-						<h4>Download the full imageset</h4>
+						<h4>Download the full image set</h4>
 
-						<p>To download the full imageset, download the repo from GitHub using the button below. You&rsquo;ll find all the image files in the <code>/{{imageset_path}}</code> folder.</p>
+						<p>To download the full image set, download the repo from GitHub using the button below. You&rsquo;ll find all the image files in the <code>/{{imageset_path}}</code> folder.</p>
 
-						<a href="{{repo_home_url}}/archive/master.zip" class="o-buttons o-buttons--wide">Download the imageset</a>
+						<a href="{{repo_home_url}}/archive/master.zip" class="o-buttons o-buttons--wide">Download the image set</a>
 
 
 					{% endif %}

--- a/app/views/component-detail.html
+++ b/app/views/component-detail.html
@@ -65,7 +65,7 @@
 				</aside>
 			{% endif %}
 
-			{% if origami_type == 'imageset' %}
+			{% if origami_type == 'imageset' and imageset_list %}
 				{% include "blocks/imageset-demo.html" %}
 			{% endif %}
 

--- a/app/views/component-detail.html
+++ b/app/views/component-detail.html
@@ -40,15 +40,15 @@
 						<h2>Quick start</h2>
 
 						<h3>Use the imageset</h3>
-						<p>Imageset images can be loaded directly using the imageservice. This shortcode for this imageset is: <code>fticon-v1</code></p>
+						<p>Imageset images can be loaded directly using the imageservice. This shortcode for this imageset is: <code>{{imageset_scheme}}</code></p>
 
 						<p>To load an image from this imageset, use the following URL for the build service:</p>
 
-						<pre><code class="lang-html">//image.webservices.ft.com/v1/images/raw/fticon-v1:{image-name}</code></pre>
+						<pre><code class="lang-html">//image.webservices.ft.com/v1/images/raw/{{imageset_scheme}}:{image-name}</code></pre>
 
 						<h4>Download the full imageset</h4>
 
-						<p>To download the full imageset, download the repo from GitHub using the button below. You&rsquo;ll find all the image files in the <code>/src</code> folder.</p>
+						<p>To download the full imageset, download the repo from GitHub using the button below. You&rsquo;ll find all the image files in the <code>/{{imageset_path}}</code> folder.</p>
 
 						<a href="{{repo_home_url}}/archive/master.zip" class="o-buttons o-buttons--wide">Download the imageset</a>
 

--- a/app/views/component-detail.html
+++ b/app/views/component-detail.html
@@ -44,7 +44,7 @@
 
 						<p>To download the full imageset, download the repo from GitHub using the button below. You&rsquo;ll find all the image files in the <code>/src</code> folder.</p>
 
-						<a href="{{repo_home_url}}/archive/master.zip" class="o-buttons o-buttons--big o-registry__github-button">Download the imageset</a>
+						<a href="{{repo_home_url}}/archive/master.zip" class="o-buttons o-buttons--wide">Download the imageset</a>
 
 
 					{% endif %}
@@ -63,6 +63,10 @@
 					<h4>Warning: this version is unstable</h4>
 					<p>This is an unstable pre-release of an upcoming version of this component.  Its API may be subject to breaking changes.</p>
 				</aside>
+			{% endif %}
+
+			{% if origami_type == 'imageset' %}
+				{% include "blocks/imageset-demo.html" %}
 			{% endif %}
 
 			{% if demos %}

--- a/app/views/component-detail.html
+++ b/app/views/component-detail.html
@@ -37,8 +37,14 @@
 					{% endif %}
 
 					{% if origami_type == 'imageset' %}
+						<h2>Quick start</h2>
+
 						<h3>Use the imageset</h3>
-						<p>Imageset images can be loaded directly using the imageservice. This shortcode for this imageset is: ...</p>
+						<p>Imageset images can be loaded directly using the imageservice. This shortcode for this imageset is: <code>fticon-v1</code></p>
+
+						<p>To load an image from this imageset, use the following URL for the build service:</p>
+
+						<pre><code class="lang-html">//image.webservices.ft.com/v1/images/raw/fticon-v1:{image-name}</code></pre>
 
 						<h4>Download the full imageset</h4>
 

--- a/app/views/component-listing.html
+++ b/app/views/component-listing.html
@@ -14,7 +14,7 @@
 				<label class="o-forms-label filter-bar__label">Show:</label>
 				<input type="checkbox" name="type" value="module" class="o-forms-checkbox o-forms-checkbox--small" id="check-module" checked><label for="check-module" class="o-forms-label">Modules</label>
 				<input type="checkbox" name="type" value="service" class="o-forms-checkbox o-forms-checkbox--small" id="check-service"><label for="check-service" class="o-forms-label">Services</label>
-				<input type="checkbox" name="type" value="imageset" class="o-forms-checkbox o-forms-checkbox--small" id="check-imageset"><label for="check-imageset" class="o-forms-label">Imagesets</label>
+				<input type="checkbox" name="type" value="imageset" class="o-forms-checkbox o-forms-checkbox--small" id="check-imageset" checked><label for="check-imageset" class="o-forms-label">Imagesets</label>
 			</div>
 
 			<div class="o-forms-group filter-bar__checkboxes filter-bar__checkboxes--status">

--- a/app/views/component-listing.html
+++ b/app/views/component-listing.html
@@ -4,7 +4,6 @@
 
 <div class="o-registry-container">
 	<div class="component-list__main">
-		<h1>Component library</h1>
 		<form action="#" class="filter-bar" aria-hidden="true">
 			<div class="o-forms-group">
 				<label for="filter" aria-hidden="true">Filter modules</label>
@@ -15,6 +14,7 @@
 				<label class="o-forms-label filter-bar__label">Show:</label>
 				<input type="checkbox" name="type" value="module" class="o-forms-checkbox o-forms-checkbox--small" id="check-module" checked><label for="check-module" class="o-forms-label">Modules</label>
 				<input type="checkbox" name="type" value="service" class="o-forms-checkbox o-forms-checkbox--small" id="check-service"><label for="check-service" class="o-forms-label">Services</label>
+				<input type="checkbox" name="type" value="imageset" class="o-forms-checkbox o-forms-checkbox--small" id="check-imageset"><label for="check-imageset" class="o-forms-label">Imagesets</label>
 			</div>
 
 			<div class="o-forms-group filter-bar__checkboxes filter-bar__checkboxes--status">

--- a/public/scss/main.scss
+++ b/public/scss/main.scss
@@ -38,6 +38,7 @@ $o-overlay-is-silent: false;
 @import 'partials/component-navigation';
 @import 'partials/docs-navigation';
 @import 'partials/demos';
+@import 'partials/imageset-demo';
 @import 'partials/overlay';
 
 @import 'partials/utilities';

--- a/public/scss/partials/_buttons.scss
+++ b/public/scss/partials/_buttons.scss
@@ -1,4 +1,4 @@
-a.o-registry__github-button {
+a.o-buttons.o-registry__github-button {
 	@include oButtons;
 	@include oButtonsSize(big);
 	@include oButtonsTheme(standout);
@@ -18,3 +18,13 @@ a.o-registry__github-button i {
 	margin-right: 10px;
 }
 
+
+a.o-buttons {
+	@include oButtons;
+	@include oButtonsSize(big);
+
+	&.o-buttons--wide {
+		width: 100%;
+		margin-bottom: 15px;
+	}
+}

--- a/public/scss/partials/_component-details.scss
+++ b/public/scss/partials/_component-details.scss
@@ -63,7 +63,7 @@
 		}
 	}
 
-	.component-detail__section--highlight a {
+	.component-detail__section--highlight a:not(.o-buttons) {
 		@include oTypographySansDataBold(m);
 		font-size: 16px;
 		border-bottom: 1px dashed oColorsGetPaletteColor('teal-1');

--- a/public/scss/partials/_imageset-demo.scss
+++ b/public/scss/partials/_imageset-demo.scss
@@ -1,0 +1,21 @@
+.imageset-demo {
+	width: 100%;
+	overflow: hidden; // Clearfix cheat
+
+	&__item {
+		float: left;
+		width: 200px;
+		padding: 0 20px 20px 0;
+	}
+
+	&__image {
+		display: block;
+		width: 100%;
+		height: auto;
+		margin: 0;
+	}
+
+	&__title {
+		text-align: center;
+	}
+}


### PR DESCRIPTION
This PR:
- Adds support for the imageset module type
- Stores the imageset `imageList.json` in the database
- Generates a new demo showing all the images based on an imageset
- Shows a specific "Quick Start" guide based on the imageset being shown advising use of the Image Service
- Automatically adds the `imagesets` category to an imageset module and displays this category in the listing page and component navigation sidebar
- Gets the imageset scheme and pathToImages from the `origami-imageset-uploader` to display in the quick start guide
