### PR TITLE
Feature: cache-bust image-set demos & use v2

### DIFF
--- a/app/views/blocks/imageset-demo.html
+++ b/app/views/blocks/imageset-demo.html
@@ -7,7 +7,7 @@
 		<div class="imageset-demo">
 			{% for image in imageset_list %}
 				<div class="imageset-demo__item">
-					<img src="https://www.ft.com/__origami/service/image/v2/images/raw/{{imageset_scheme}}:{{image.name}}%3Fcache-bust%3D{{"now"|date("U")}}?source=origami-registry" alt="{{image.name}}" class="imageset-demo__image">
+					<img src="https://www.ft.com/__origami/service/image/v2/images/raw/{{imageset_scheme}}:{{image.name}}%3Fcache-bust%3D{{"now"|floor(time()/600)}}?source=origami-registry" alt="{{image.name}}" class="imageset-demo__image">
 					<p class="imageset-demo__title">{{image.name}}</p>
 				</div>
 			{% endfor %}

--- a/app/views/blocks/imageset-demo.html
+++ b/app/views/blocks/imageset-demo.html
@@ -7,7 +7,7 @@
 		<div class="imageset-demo">
 			{% for image in imageset_list %}
 				<div class="imageset-demo__item">
-					<img src="//image.webservices.ft.com/v1/images/raw/{{imageset_scheme}}:{{image.name}}?cache-bust={{"now"|date("U")}}?source=origami-registry" alt="{{image.name}}" class="imageset-demo__image">
+					<img src="https://www.ft.com/__origami/service/image/v2/images/raw/{{imageset_scheme}}:{{image.name}}?cache-bust={{"now"|date("U")}}?source=origami-registry" alt="{{image.name}}" class="imageset-demo__image">
 					<p class="imageset-demo__title">{{image.name}}</p>
 				</div>
 			{% endfor %}

--- a/app/views/blocks/imageset-demo.html
+++ b/app/views/blocks/imageset-demo.html
@@ -7,7 +7,7 @@
 		<div class="imageset-demo">
 			{% for image in imageset_list %}
 				<div class="imageset-demo__item">
-					<img src="//image.webservices.ft.com/v1/images/raw/{{imageset_scheme}}:{{image.name}}?cache-bust={{"now"|date("U")}}?source=origami-registry" alt="{{image.name}}" class="imageset-demo__image">
+					<img src="//www.ft.com/__origami/service/image/v2/images/raw/{{imageset_scheme}}:{{image.name}}?cache-bust={{"now"|date("U")}}?source=origami-registry" alt="{{image.name}}" class="imageset-demo__image">
 					<p class="imageset-demo__title">{{image.name}}</p>
 				</div>
 			{% endfor %}

--- a/app/views/blocks/imageset-demo.html
+++ b/app/views/blocks/imageset-demo.html
@@ -7,7 +7,7 @@
 		<div class="imageset-demo">
 			{% for image in imageset_list %}
 				<div class="imageset-demo__item">
-					<img src="//image.webservices.ft.com/v1/images/raw/{{imageset_scheme}}:{{image.name}}?source=origami-registry" alt="{{image.name}}" class="imageset-demo__image">
+					<img src="//image.webservices.ft.com/v1/images/raw/{{imageset_scheme}}:{{image.name}}?source=origami-registry&cache-bust={{ "now"|date("U")}}" alt="{{image.name}}" class="imageset-demo__image">
 					<p class="imageset-demo__title">{{image.name}}</p>
 				</div>
 			{% endfor %}

--- a/app/views/blocks/imageset-demo.html
+++ b/app/views/blocks/imageset-demo.html
@@ -7,7 +7,7 @@
 		<div class="imageset-demo">
 			{% for image in imageset_list %}
 				<div class="imageset-demo__item">
-					<img src="https://www.ft.com/__origami/service/image/v2/images/raw/{{imageset_scheme}}:{{image.name}}?cache-bust={{"now"|date("U")}}?source=origami-registry" alt="{{image.name}}" class="imageset-demo__image">
+					<img src="https://www.ft.com/__origami/service/image/v2/images/raw/{{imageset_scheme}}:{{image.name}}%3Fcache-bust%3D{{"now"|date("U")}}?source=origami-registry" alt="{{image.name}}" class="imageset-demo__image">
 					<p class="imageset-demo__title">{{image.name}}</p>
 				</div>
 			{% endfor %}

--- a/app/views/component-detail.html
+++ b/app/views/component-detail.html
@@ -44,7 +44,7 @@
 
 						<p>To load an image from this image set, use the following URL for the Image Service:</p>
 
-						<pre><code class="lang-html">//image.webservices.ft.com/v1/images/raw/{{imageset_scheme}}:{image-name}?source={your-source-here}</code></pre>
+						<pre><code class="lang-html">//www.ft.com/__origami/service/image/v2/images/raw/{{imageset_scheme}}:{image-name}?source={your-source-here}</code></pre>
 
 						<h4>Download the full image set</h4>
 


### PR DESCRIPTION
This PR adds a new query parameter the the image-set demo img tag with the value of the current time in unix time format. This will act as a cache-buster to always show the latest image-set.
