### PR TITLE
wrapping data.url processing in postMessage in conditional statement,…

### DIFF
--- a/app/views/embedapi-js.html
+++ b/app/views/embedapi-js.html
@@ -24,7 +24,7 @@ var OrigamiRegistry = (function() {
 	function processPostMessage(msg) {
 		var data, ifr, plusborders, style;
 		try { data = JSON.parse(msg.data); } catch (e) { return; }
-		if(data.url){
+		if (data.url) {
 			data.url = data.url.replace(location.protocol+'\/\/'+location.hostname, '');
 		}
 		if (data.type == 'resize' && (ifr = document.querySelector('iframe[src="'+data.url+'"]'))) {

--- a/app/views/embedapi-js.html
+++ b/app/views/embedapi-js.html
@@ -24,7 +24,9 @@ var OrigamiRegistry = (function() {
 	function processPostMessage(msg) {
 		var data, ifr, plusborders, style;
 		try { data = JSON.parse(msg.data); } catch (e) { return; }
-		data.url = data.url.replace(location.protocol+'\/\/'+location.hostname, '');
+		if(data.url){
+			data.url = data.url.replace(location.protocol+'\/\/'+location.hostname, '');
+		}
 		if (data.type == 'resize' && (ifr = document.querySelector('iframe[src="'+data.url+'"]'))) {
 			style = getComputedStyle(ifr);
 			plusborders = style.getPropertyValue('box-sizing') == 'border-box';


### PR DESCRIPTION
… as adverts use postMessage and might not have url property

This is breaking demo adverts, e.g.: https://origami-build.ft.com/v2/demos/o-ads@6.0.2/Responsive-Ad

As advert use `window.postMessage` to communicate with the top window.