### PR TITLE
Fix demo descriptions

### DIFF
--- a/app/views/blocks/demo.html
+++ b/app/views/blocks/demo.html
@@ -48,7 +48,7 @@
 
 	{% if demo.description %}
 		<footer class="demo__footer">
-			{{ demo.description }}
+			{{ demo.description|markdown|raw }}
 		</footer>
 	{% endif %}
 </div>

--- a/app/views/page.html
+++ b/app/views/page.html
@@ -11,7 +11,7 @@
 	<link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css" />
 
 	<!-- Registry-specific styles -->
-	<link rel="stylesheet" href="/main.css?v89" />
+	<link rel="stylesheet" href="/main.css?v90" />
 
 	<!-- Google Analytics tracking code -->
 	<script>
@@ -83,6 +83,6 @@
 	</footer>
 
 	<script src="/js/libs/jquery.min.js"></script>
-	<script src="/main.js?v89"></script>
+	<script src="/main.js?v90"></script>
 </body>
 </html>

--- a/public/scss/partials/_demos.scss
+++ b/public/scss/partials/_demos.scss
@@ -74,8 +74,12 @@
 }
 
 .demo__footer {
-	padding: 10px 0;
+	padding: 10px 0 0;
 	color: #4a4a4a;
+
+	p {
+		margin-top: 0;
+	}
 }
 
 .demo__frame-container {


### PR DESCRIPTION
Fixes the `HTML` bug in `o-forms` and allows `HTML` to be used in demo descriptions