### PR TITLE
Imageset logging

### DIFF
--- a/app/classes/Origami/ComponentVersion.php
+++ b/app/classes/Origami/ComponentVersion.php
@@ -401,7 +401,18 @@ final class ComponentVersion extends Model {
 					self::$app->logger->notice('Bad imageset uploader HTTP response', $logdata);
 				}
 
-				$this->image_list = json_encode($responseJson);
+				$image_list = json_encode($responseJson);
+
+				if ($image_list) {
+					$this->image_list = $image_list;
+				} else {
+					$logdata = array(
+						'component' => $name,
+						'error' => 'unable to build image_list',
+						'image_list' => $image_list,
+					);
+					self::$app->logger->error('Unable to build image_list', $logdata);
+				}
 			}
 		}
 	}

--- a/app/classes/Origami/ComponentVersion.php
+++ b/app/classes/Origami/ComponentVersion.php
@@ -380,16 +380,25 @@ final class ComponentVersion extends Model {
 				if ($oiu_response->getResponseStatusCode() == 200) {
 					$oui_json = json_decode($oiu_response->getBody());
 
-					if (property_exists($oui_json, $this->component->module_name)) {
-						$imageset_map_data = $oui_json->{$this->component->module_name};
+					if (property_exists($oui_json, $name)) {
+						$imageset_map_data = $oui_json->{$name};
 
-						if ($this->component->module_name === 'fticons') {
+						if ($name === 'fticons') {
 							$scheme_version = '-v' . explode('.', $this->tag_name)[0];
 							$imageset_map_data->scheme .= $scheme_version;
 						}
 
 						$responseJson->imageset_data = $imageset_map_data;
 					}
+				} else {
+					$logdata = array(
+						'component' => $name,
+						'status_code' => $oiu_response->getResponseStatusCode(),
+					);
+					if (!in_array($oiu_response->getResponseStatusCode(), array(404,403))) {
+						$logdata['response'] = $oiu_response->getBody();
+					}
+					self::$app->logger->notice('Bad imageset uploader HTTP response', $logdata);
 				}
 
 				$this->image_list = json_encode($responseJson);


### PR DESCRIPTION
Improves the logging around imageset building in the repository discovery.

If there's no 200 responses from the Github curl request this will be logged, and if the `$image_list` variable generated is `null` then we get an error.

This isn't a final solution, but it's a step in the direction of finding out some reasons why the imageset demos might be failing to build.