### PR TITLE
Lower rebuild depth from 30 to 10

### DIFF
--- a/app/classes/Origami/Component.php
+++ b/app/classes/Origami/Component.php
@@ -14,7 +14,7 @@ use \FTLabs\MySqlQueryException;
 
 final class Component extends Model {
 
-	const REBUILD_DEPENDENTS_DEPTH = 30;
+	const REBUILD_DEPENDENTS_DEPTH = 10;
 
 	protected $fields = array('id', 'module_name', 'keywords', 'origami_category', 'git_repo_url', 'is_origami', 'host_type', 'datetime_last_discovered', 'recent_commit_count');
 	protected $datefields = array('datetime_last_discovered');


### PR DESCRIPTION
Continuing with the plan in place to reduce the number of questions being made to the DB, we now have some consistent-ish tracking in Grafana, so this PR reduces the depth of the rebuild done on components when a new component is updated. This _should_ reduce the queries made during the update registry script run.