### PR TITLE
Use the imageset version as the cache-busting parameter instead of every 10 minutes

### DIFF
--- a/app/classes/Controllers/ComponentDetail.php
+++ b/app/classes/Controllers/ComponentDetail.php
@@ -120,7 +120,7 @@ class ComponentDetail extends BaseController {
 				}
 			}
 
-			$this->addViewData('imageset_cachebust', floor(time()/600) );
+			$this->addViewData('imageset_cachebust', $this->version->tag_name );
 		}
 
 		// Certain older versions of o-colors cannot be demoed via the /demo endpoint


### PR DESCRIPTION
Currently we are cache busting imageset demos with a value which changes every 10 minutes. Considering the fact that imagesets are not updated frequently, this is not necessary. When an Imageset is updated, it's version number is also updated, we can use the imageset version number as the cache-busting value so that we only cache-bust when there has been an update to an imageset.