### PR TITLE
Improve local Docker development and get Docker working on Heroku once again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
 FROM heroku/heroku:16
 
+RUN useradd --home-dir /app app
+
 ENV APPLICATION /app/user
 ENV PHP_VERSION 5.6.15
 ENV HTTPD_VERSION 2.4.17
 ENV NGINX_VERSION 1.8.0
 ENV PORT 3002
 ENV STACK heroku-16
+# So we can run PHP in here - Required by our start.sh script used in development
+ENV PATH /app/.heroku/php/bin:/app/.heroku/php/sbin:$PATH
 
 WORKDIR $APPLICATION
+COPY install.sh /app/user/
+RUN ./install.sh
 
 COPY composer.lock /app/user/
 COPY composer.json /app/user/
@@ -18,11 +24,8 @@ RUN unzip -q /heroku-buildpack-php-master.zip -d /
 RUN /heroku-buildpack-php-master/bin/detect $APPLICATION
 RUN /heroku-buildpack-php-master/bin/compile $APPLICATION/ /tmp
 
-
 EXPOSE $PORT
 
-# So we can run PHP in here - Required by our start.sh script used in development
-ENV PATH /app/.heroku/php/bin:/app/.heroku/php/sbin:$PATH
 
 # FPM socket permissions workaround when run as root
 RUN echo "\n\
@@ -36,3 +39,7 @@ user nobody root;\n\
 
 # Avoid https://app.getsentry.com/nextftcom/registry/issues/82164697/
 RUN echo "always_populate_raw_post_data = -1\n" >> /app/.heroku/php/etc/php/php.ini
+
+RUN chown -R app /app
+USER app
+CMD PATH=/app/.heroku/php/bin:/app/.heroku/php/sbin:$PATH vendor/bin/heroku-php-apache2 public/

--- a/README.md
+++ b/README.md
@@ -17,31 +17,7 @@ Table of Contents
 Requirements
 ------------
 
-To set up a development environment, download and install the docker toolkit (https://docs.docker.com/engine/getstarted/step_one/).  You'll need `docker-compose` and `docker`.  Or use homebrew:
-
-```sh
-brew tap caskroom/homebrew-cask
-brew install brew-cask
-brew cask install docker-machine docker-compose
-```
-
-You may now have to change the owner of your `.docker` directory if the owner is root:
-
-```sh
-chown -R `whoami` ~/.docker
-```
-
-You'll also need `gulp` installed globally to compile the front-end assets:
-
-```sh
-npm install -g gulp
-```
-
-Create a virtual machine to run the application's containers using `docker-machine`. The default size isn't large enough, so this will create one with an increased disk size:
-
-```sh
-docker-machine create --driver virtualbox --virtualbox-disk-size "50000" dev
-```
+To set up a development environment, download and install docker for mac (https://store.docker.com/editions/community/docker-ce-desktop-mac).
 
 
 Running locally
@@ -49,33 +25,17 @@ Running locally
 
 Before we can run the application, we'll need to create a `.env` file. You can copy the `sample.env` file to `.env` and fill in the missing values from the Origami Registry Configuration note in the shared folder on LastPass.
 
-In the working directory, use `docker-machine` to start the development machine (if you've just created the machine you skip this step):
-
-```sh
-docker-machine start dev
-```
-
-Once started, put the machine's config into your environment. Both right now and on next login:
-
-```sh
-docker-machine env dev
-eval $(docker-machine env dev)
-echo "eval $(docker-machine env dev)" >> ~/.profile
-```
-
-*depending on your machine you might need to remove the `$` in the `eval` statement, after running the first line, there will be instructions in your command line.
-
-Then use `docker-compose` to build and start the container:
+Use `docker-compose` to build and start the container:
 
 ```sh
 docker-compose build
 docker-compose up
 ```
 
-Now you can access the app over HTTP on port `3000`. If you're on a Mac, you'll need to use the IP of your Docker Machine, which you can get by running `docker-machine ip dev`:
+Now you can access the app over HTTP on port `3000`.
 
 ```sh
-open "http://$(docker-machine ip dev):3000/"
+open "localhost:3000"
 ```
 
 The MySQL database is accessible on port 3306, the settings for which are in the `.env` file.
@@ -107,7 +67,6 @@ To work with the Registry locally you will probably need some data in your local
 To run the update script locally, you will need to SSH into the Docker VM and the container for the Registry:
 
 ```sh
-docker-machine ssh dev
 docker ps
 docker exec -i -t origamiregistry_web_1 bash
 ```
@@ -148,11 +107,7 @@ We've outlined some common issues that can occur when running the Registry local
 
 ### What do I do if the dependencies won't install?
 
-This is likely because you're on a different network which doesn't allow you access to the private FT repositories. Make sure you're connected to the internal network/wifi, then restart the `docker-machine` to make sure `docker-compose` has access to the correct network.
-
-### What can I do to fix `docker-compose` not starting?
-
-If you get an error when running `docker-compose up` the easiest solution is to kill the `docker-machine` and start the setup process again. Run `docker-machine kill dev` to stop the machine. Then make sure you're on the internal network, and start the [Running locally](#running-locally) process from the beginning.
+This is likely because you're on a different network which doesn't allow you access to the private FT repositories. Make sure you're connected to the internal network/wifi, to make sure `docker-compose` has access to the correct network.
 
 ### The discovery script has stopped running hourly on production.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Table of Contents
   * [Requirements](#requirements)
   * [Running Locally](#running-locally)
   * [Configuration](#configuration)
-  * [Deployment](#deployment)
+  * [Deploying](#deploying)
   * [Trouble-Shooting](#trouble-shooting)
   * [License](#license)
 
@@ -81,10 +81,10 @@ php ./app/scripts/updateregistry
 Deploying
 ---------
 
-You need to authenticate with Heroku (this app is `origami-registry-eu`) and use the Heroku docker plugin: `heroku plugins:install heroku-docker`. Then run the following to push the lastest changes to production:
+You need to authenticate with Heroku (this app is `origami-registry-eu`) and use the Heroku container plugin: `heroku plugins:install heroku-container-tools`. Then run the following to push the lastest changes to production:
 
 ```sh
-git describe --tags > ./appversion && heroku docker:release --app origami-registry-eu && rm -f ./appversion
+git describe --tags > ./appversion && heroku container:push web --app origami-registry-eu && rm -f ./appversion
 ```
 
 ### Deploying to QA
@@ -92,7 +92,7 @@ git describe --tags > ./appversion && heroku docker:release --app origami-regist
 To update the QA version of the Registry, use the same process as above but deploy to the app `origami-registry-qa` instead:
 
 ```sh
-git describe --tags > ./appversion && heroku docker:release --app origami-registry-qa && rm -f ./appversion
+git describe --tags > ./appversion && heroku container:push web --app origami-registry-qa && rm -f ./appversion
 ```
 
 ### Architecture

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+exec 2>&1
+set -e
+set -x
+
+apt-get update
+apt-get install -y --force-yes \
+    autoconf \
+    bison \
+    build-essential \
+    libacl1-dev \
+    libapparmor-dev \
+    libapt-pkg-dev \
+    libattr1-dev \
+    libaudit-dev \
+    libbsd-dev \
+    libbz2-dev \
+    libcairo2-dev \
+    libcap-dev \
+    libcurl4-openssl-dev \
+    libdb-dev \
+    libev-dev \
+    libevent-dev \
+    libexif-dev \
+    libffi-dev \
+    libgcrypt20-dev \
+    libgd-dev \
+    libgdbm-dev \
+    libgeoip-dev \
+    libglib2.0-dev \
+    libgnutls-dev \
+    libicu-dev \
+    libidn11-dev \
+    libjpeg-dev \
+    libkeyutils-dev \
+    libkmod-dev \
+    libkrb5-dev \
+    libldap2-dev \
+    liblz4-dev \
+    libmagic-dev \
+    libmagickwand-dev \
+    libmcrypt-dev \
+    libmemcached-dev \
+    libmysqlclient-dev \
+    libncurses5-dev \
+    libncursesw5-dev \
+    libnetpbm10-dev \
+    libpam0g-dev \
+    libpopt-dev \
+    libpq-dev \
+    librabbitmq-dev \
+    libreadline-dev \
+    librtmp-dev \
+    libselinux1-dev \
+    libsemanage1-dev \
+    libssl-dev \
+    libsystemd-dev \
+    libudev-dev \
+    libuv1-dev \
+    libwrap0-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libyaml-dev \
+    postgresql-server-dev-9.6 \
+    python-dev \
+    ruby-dev \
+    zlib1g-dev \
+
+cd /
+rm -rf /root/*
+rm -rf /tmp/*
+rm -rf /var/cache/apt/archives/*.deb


### PR DESCRIPTION
Docker For Mac has been stable for a long time now, switching to this for local development has simplified the set up considerably.

Heroku run the Docker container under a non-root user, which has meant modifying the Docker image to have everything work for a non-root user.

Heroku's docker plugin was replaced with a generic "container-tools" plugin.