### PR TITLE
Tweak sidebar API docs to give new canonical registry endpoint

### DIFF
--- a/app/views/component-listing.html
+++ b/app/views/component-listing.html
@@ -79,7 +79,7 @@
 			<pre><code class="lang-json">{
   "registry": {
     "search": [
-      "http://{{SERVER.HTTP_HOST}}",
+      "https://origami-bower-registry.ft.com",
       "https://registry.bower.io"
     ]
   }


### PR DESCRIPTION
I think this is always going to be different from the Registry web url now, so best to hardcode it..?